### PR TITLE
Refactor math.pow to ^ operator for Lua 5.3+ compatibility

### DIFF
--- a/lib/external/filesize.lua
+++ b/lib/external/filesize.lua
@@ -77,9 +77,9 @@ local function filesize(size, options)
 
         local val
         if o.base == 2 then
-            val = size / math.pow(2, o.exponent * 10)
+            val = size / math.pow(2^o.exponent * 10)
         else
-            val = size / math.pow(1000, o.exponent)
+            val = size / math.pow(1000^o.exponent)
         end
 
         if o.bits then


### PR DESCRIPTION
Old version using math.pow
`local result = math.pow(x, y)`

Updated version using the ^ operator
`local result = x ^ y`

Official documentation:
[https://www.lua.org/manual/5.3/manual.html#8.2](https://www.lua.org/manual/5.3/manual.html#8.2)