### PR TITLE
Add basic AMD support via amdgpu_top

### DIFF
--- a/lib/components/gpu.lua
+++ b/lib/components/gpu.lua
@@ -93,9 +93,9 @@ local function parse_amdgpu_top_output(output, top)
   for line in output:gmatch("[^\r\n]+") do
       table.insert(lines, line)
   end
-  local top_n = top or #lines
+  local top_n = top * 3 or #lines
 
-  for i = 3, top_n * 3, 3 do
+  for i = 3, top_n, 3 do
       local line = lines[i]
       local process_name, pid, vram = line:match("(%S+)%s+%(%s+(%d+)%)%s*,.-%bVRAM%s+(%d+)%s+MiB")
       if process_name and pid and vram then

--- a/lib/components/gpu.lua
+++ b/lib/components/gpu.lua
@@ -85,4 +85,149 @@ function gpu.nvidia(args)
     }
 end
 
+local function parse_amdgpu_top_output(output, top)
+  local processes = {}
+
+  local lines = {}
+  -- Split the output into lines and discard the first three lines
+  for line in output:gmatch("[^\r\n]+") do
+      table.insert(lines, line)
+  end
+  local top_n = top or #lines
+
+  for i = 3, top_n * 3, 3 do
+      local line = lines[i]
+      local process_name, pid, vram = line:match("(%S+)%s+%(%s+(%d+)%)%s*,.-%bVRAM%s+(%d+)%s+MiB")
+      if process_name and pid and vram then
+          -- Store the extracted information in a table
+          table.insert(processes, {
+              name = process_name,
+              pid = tonumber(pid),
+              gpu_mem = tonumber(vram),
+              gpu_util = 0 -- for now there's no way for obtaining it
+
+          })
+      end
+  end
+
+  return processes
+end
+
+lcc.tpl.amd_gpu = [[
+{% for _, g in ipairs(gpu_info) do %}
+${font}${color}{%= g.gpu_util %}%${alignc $sr{-16}}{%= g.model_name %}${alignr}{%= g.gpu_temp %}℃
+${color3}${lua_graph "echo {%= g.gpu_util %}" {%= lcc.half_graph_size %}} ${alignr}${lua_graph "echo {%= g.gpu_temp %}" {%= lcc.half_graph_size %} {%= g.gpu_temp_thres %}}${color}
+${color2}${lua font h2 FAN}${goto $sr{148}}${lua font h2 POWER}${font}${color}${alignr}${offset $sr{-138}}{%= g.fan_util %}%
+${voffset $sr{-13}}${alignr}${lua format %.1f {%= g.power_usage %}}W
+${color3}${lua_bar {%= lcc.half_bar_size %} echo {%= g.fan_util %}} ${color}${alignr}${lua_bar {%= lcc.half_bar_size %} ratio_perc {%= g.power_usage %} {%= g.power_limit %}}
+${color2}${lua font h2 MEM}${font}${color} ${alignc $sr{-16}}{%= g.mem_used_h %} / {%= g.mem_total_h %} ${alignr}{%= g.mem_util %} ${color2}${lua font h2 UT}
+${color3}${lua_bar ratio_perc {%= g.mem_used %} {%= g.mem_total %}}${color}
+{% if g.processes then %}
+${color2}${lua font h2 {PROCESS ${goto $sr{156}}PID ${goto $sr{194}}MEM%${alignr}GPU%}}${font}${color}#
+{% for _, p in ipairs(g.processes) do +%}
+{%= p.name %} ${goto $sr{156}}{%= p.pid %}${alignr}${offset $sr{-44}}${lua ratio_perc {%= p.gpu_mem %} {%= g.mem_total %} 2}
+${voffset $sr{-13}}${alignr}${lua format %.1f {%= p.gpu_util %}}{% end %}{% end %}
+{% end %}
+]]
+
+local function _amd_gpu_info(top_n)
+  local json = require('json')
+
+  local function read_file(path)
+      local file = io.open(path, "r")
+      if file then
+          local content = file:read("*a")
+          file:close()
+          return content
+      end
+      return nil
+  end
+
+  local function read_from_std(command)
+    local handle = io.popen(command)
+    local data = handle:read("*a")
+    handle:close()
+    if data then
+        return data
+    end
+
+    return nil
+  end
+
+  local function get_gpu_busy_percent(card)
+      local path = string.format("/sys/class/drm/card%s/device/gpu_busy_percent", card)
+      local content = read_file(path)
+      return content and tonumber(content) or 0
+  end
+
+  -- Detect available GPU cards
+  local gpu_cards = {}
+  for i = 0, 10 do  -- Assuming up to 10 cards; adjust as necessary
+      local path = string.format("/sys/class/drm/card%s/device", i)
+      local f = io.popen("ls " .. path .. " 2>/dev/null")
+      if f:read("*a") ~= "" then
+          table.insert(gpu_cards, tostring(i))
+      end
+      f:close()
+  end
+
+  local json_data = read_from_std("amdgpu_top -d -J")
+  local processes_dump = read_from_std("amdgpu_top -p")
+
+  local data = json.decode(json_data)
+  if not data or not data[1] then return end
+
+  local sensors = data[1].Sensors
+  local power_cap = data[1]["Power Cap"]
+  local vram = data[1]["VRAM"]
+  local device_name = data[1].DeviceName
+  local fan_max = 3800 --  temp hotfix before amdgpu_top gets an update
+  if sensors["Fan Max"] and sensors["Fan Max"].value then
+      fan_max = sensors["Fan Max"].value
+  end
+
+  local gpu_info = {}
+
+  for _, card in ipairs(gpu_cards) do
+      table.insert(gpu_info, {
+          model_name = device_name or "AMD GPU",
+          gpu_util = get_gpu_busy_percent(card),
+          gpu_temp = sensors["Edge Temperature"].value,
+          gpu_temp_thres = 100,  -- Assuming 100°C as threshold, adjust as needed
+          fan_speed = sensors["Fan"].value,
+          fan_util = string.format("%.2f", (sensors["Fan"].value / fan_max) * 100),
+          power_usage = sensors["Average Power"].value,
+          power_limit = power_cap.current,
+          mem_used = vram["Total VRAM Usage"].value,
+          mem_total = vram["Total VRAM"].value,
+          mem_util = string.format("%.2f%%", (vram["Total VRAM Usage"].value / vram["Total VRAM"].value) * 100),
+          processes = parse_amdgpu_top_output(processes_dump, top_n)
+      })
+  end
+
+  for _, g in ipairs(gpu_info) do
+    g.mem_used_h = utils.filesize(g.mem_used * 1024 * 1024)
+    g.mem_total_h = utils.filesize(g.mem_total * 1024 * 1024)
+  end
+
+  return utils.trim(lcc.tpl.amd_gpu { gpu_info = gpu_info })
+end
+
+function conky_amd(interv, top_n)
+  local rendered = core._interval_call(
+      interv, _amd_gpu_info, tonumber(top_n or 0)
+  )
+  if rendered then return rendered end
+end
+
+lcc.tpl.amd = [[${lua amd {%= interv %} {%= top_n %}}]]
+function gpu.amd(args)
+  local interv = utils.table.get(args, 'interv', 4)
+  local top_n = utils.table.get(args, 'top_n', 5)
+  return core.section("GPU", "") .. "\n" .. lcc.tpl.amd {
+      interv = interv,
+      top_n = top_n
+  }
+end
+
 return gpu

--- a/lib/components/gpu.lua
+++ b/lib/components/gpu.lua
@@ -89,7 +89,6 @@ local function parse_amdgpu_top_output(output, top)
   local processes = {}
 
   local lines = {}
-  -- Split the output into lines and discard the first three lines
   for line in output:gmatch("[^\r\n]+") do
       table.insert(lines, line)
   end
@@ -97,7 +96,8 @@ local function parse_amdgpu_top_output(output, top)
 
   for i = 3, top_n, 3 do
       local line = lines[i]
-      local process_name, pid, vram = line:match("(%S+)%s+%(%s+(%d+)%)%s*,.-%bVRAM%s+(%d+)%s+MiB")
+      local process_name, pid, vram = line:match("([^%s]+)%s+%(%s*(%d+)%s*%).*VRAM%s+(%d+)%s+MiB")
+
       if process_name and pid and vram then
           -- Store the extracted information in a table
           table.insert(processes, {
@@ -119,7 +119,7 @@ ${font}${color}{%= g.gpu_util %}%${alignc $sr{-16}}{%= g.model_name %}${alignr}{
 ${color3}${lua_graph "echo {%= g.gpu_util %}" {%= lcc.half_graph_size %}} ${alignr}${lua_graph "echo {%= g.gpu_temp %}" {%= lcc.half_graph_size %} {%= g.gpu_temp_thres %}}${color}
 ${color2}${lua font h2 FAN}${goto $sr{148}}${lua font h2 POWER}${font}${color}${alignr}${offset $sr{-138}}{%= g.fan_util %}%
 ${voffset $sr{-13}}${alignr}${lua format %.1f {%= g.power_usage %}}W
-${color3}${lua_bar {%= lcc.half_bar_size %} echo {%= g.fan_util %}} ${color}${alignr}${lua_bar {%= lcc.half_bar_size %} ratio_perc {%= g.power_usage %} {%= g.power_limit %}}
+${color3}${lua_bar {%= lcc.half_bar_size %} echo {%= g.fan_util %}} ${color3}${alignr}${lua_bar {%= lcc.half_bar_size %} ratio_perc {%= g.power_usage %} {%= g.power_limit %}}
 ${color2}${lua font h2 MEM}${font}${color} ${alignc $sr{-16}}{%= g.mem_used_h %} / {%= g.mem_total_h %} ${alignr}{%= g.mem_util %} ${color2}${lua font h2 UT}
 ${color3}${lua_bar ratio_perc {%= g.mem_used %} {%= g.mem_total %}}${color}
 {% if g.processes then %}


### PR DESCRIPTION
Hi, I've came up with following solution for AMD GPUs, it's not the prettiest but it works for me, it requires [lua-json](https://github.com/rxi/json.lua) and [amdgpu_top](https://github.com/Umio-Yasuno/amdgpu_top), if you decide that it's not good enough, maybe some of the code will be useful for someone? :) Will gladly adjust it further.

![image](https://github.com/jxai/lean-conky-config/assets/96987701/54c3d86c-8406-412f-be19-a6312eea29c5)


I've tried using using similar approach as you did for nvidia.