### PR TITLE
fix: Handle pynvml binding return NoneObject 

### DIFF
--- a/lib/components/gpu_nvml
+++ b/lib/components/gpu_nvml
@@ -108,7 +108,7 @@ with nvml():
 
         if len(processes) > 0:
             timestamp = 0  # list all processes
-            samples = q("nvmlDeviceGetProcessUtilization", timestamp)
+            samples = q("nvmlDeviceGetProcessUtilization", timestamp, default=[])
             for s in samples:
                 if s.pid in processes:
                     processes[s.pid].update(


### PR DESCRIPTION
In some cases `nvmlDeviceGetProcessUtilization` may return `NVML_ERROR_NOT_FOUND` as per the [documentation](https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1gb0ea5236f5e69e63bf53684a11c233bd). If this happens, the `pynvml` binding is going to return a None Object, thus breaking the `gpu_nvml` script with the following error `TypeError: 'NoneType' object is not iterable`