### PR TITLE
gpu_nvml crashes (TypeError) on GPUs without power sensor / process-utilization support (e.g. Quadro T400)

### DIFF
--- a/lib/components/gpu_nvml
+++ b/lib/components/gpu_nvml
@@ -85,8 +85,8 @@ with nvml():
             pynvml.NVML_TEMPERATURE_THRESHOLD_GPU_MAX,
             default=100,
         )
-        print_entry("power_usage", q("nvmlDeviceGetPowerUsage") / 1000.0)
-        print_entry("power_limit", q("nvmlDeviceGetPowerManagementLimit") / 1000.0)
+        print_entry("power_usage", q("nvmlDeviceGetPowerUsage", default=0) / 1000.0)
+        print_entry("power_limit", q("nvmlDeviceGetPowerManagementLimit", default=0) / 1000.0)
 
         processes = {}
         for proc_type, proc_query in (
@@ -108,7 +108,7 @@ with nvml():
 
         if len(processes) > 0:
             timestamp = 0  # list all processes
-            samples = q("nvmlDeviceGetProcessUtilization", timestamp, default=[])
+            samples = q("nvmlDeviceGetProcessUtilization", timestamp, default=[]) or []
             for s in samples:
                 if s.pid in processes:
                     processes[s.pid].update(


### PR DESCRIPTION
## Description
`gpu_nvml` crashes with an unhandled exception when one of the detected GPUs 
doesn't expose certain NVML metrics. Since all GPUs are processed in a single 
script run, a missing metric on ANY one GPU breaks the panel for every GPU on 
the system — including ones that work fine.

Reproduced with a dual-GPU setup: GeForce GTX 1650 + Quadro T400 (the T400 has 
no onboard power sensor and apparently doesn't return per-process utilization 
samples).

## Traceback 1 — power_usage/power_limit
print_entry("power_usage", q("nvmlDeviceGetPowerUsage") / 1000.0) divides by 
None when the GPU doesn't report power usage:

TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'

## Traceback 2 — process utilization
samples = q("nvmlDeviceGetProcessUtilization", timestamp, default=[])
for s in samples:

TypeError: 'NoneType' object is not iterable

This call apparently returns None directly (not via exception) when no recent 
sample is available, so the existing `default=` kwarg (which only triggers on 
exceptions) doesn't help.

## Suggested fix
print_entry("power_usage", q("nvmlDeviceGetPowerUsage", default=0) / 1000.0)
print_entry("power_limit", q("nvmlDeviceGetPowerManagementLimit", default=0) / 1000.0)
...
samples = q("nvmlDeviceGetProcessUtilization", timestamp) or []

This PR contains both fixes.